### PR TITLE
[LATE_APPEAL_SMALLER_LABEL] - Making a late appeal text is now smaller

### DIFF
--- a/app/views/MakingALateAppealPage.scala.html
+++ b/app/views/MakingALateAppealPage.scala.html
@@ -34,6 +34,7 @@
         @textArea(form, "late-appeal-text", messages("makingALateAppeal.heading"),
             isPageHeading = true,
             describedBy = Some("late-appeal-text-hint"),
+            labelClasses = Some("govuk-label--l"),
             hint = Some(Html(messages("makingALateAppeal.p1"))))
         @govukButton(Button(content = Text(messages("common.continue"))))
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53828896/122415708-0dd8af00-cf80-11eb-94d2-a19f1e181e38.png)
