### PR TITLE
[PRM-1456]: updated appeal start page to use time machine

### DIFF
--- a/app/controllers/AppealStartController.scala
+++ b/app/controllers/AppealStartController.scala
@@ -58,10 +58,10 @@ class AppealStartController @Inject()(appealStartPage: AppealStartPage)(implicit
   private def isAppealLate()(implicit request: Request[_]): Boolean = {
     if(isEnabled(UseNewAPIModel)) {
       val dateCommunicationSentParsedAsLocalDate = LocalDate.parse(request.session.get(SessionKeys.dateCommunicationSent).get)
-      dateCommunicationSentParsedAsLocalDate.isBefore(LocalDate.now().minusDays(appConfig.daysRequiredForLateAppeal))
+      dateCommunicationSentParsedAsLocalDate.isBefore(getFeatureDate.minusDays(appConfig.daysRequiredForLateAppeal))
     } else {
       val dateCommunicationSentParsed = LocalDateTime.parse(request.session.get(SessionKeys.dateCommunicationSent).get)
-      dateCommunicationSentParsed.isBefore(LocalDateTime.now().minusDays(appConfig.daysRequiredForLateAppeal))
+      dateCommunicationSentParsed.isBefore(getFeatureDate.atStartOfDay.minusDays(appConfig.daysRequiredForLateAppeal))
     }
   }
 }


### PR DESCRIPTION
Tested manually on local using the default `vrn: 224060020`. By default late appeal content was displayed but was removed when the date was changed with using the test-only route `/test-only/time-machine-now?dateToSet=2021-05-23`