### PR TITLE
[PRM-1618] - Added LPP1/LPP2 communications date and changed heading + routing

### DIFF
--- a/app/controllers/InitialiseAppealController.scala
+++ b/app/controllers/InitialiseAppealController.scala
@@ -82,12 +82,16 @@ class InitialiseAppealController @Inject()(appealService: AppealService,
         val firstPenaltyChargeReference = data.firstPenaltyChargeReference
         val parsedSecondPenaltyAmount = CurrencyFormatter.parseBigDecimalToFriendlyValue(data.secondPenaltyAmount)
         val secondPenaltyChargeReference = data.secondPenaltyChargeReference
+        val firstPenaltyCommunicationDate = data.firstPenaltyCommunicationDate
+        val secondPenaltyCommunicationDate = data.secondPenaltyCommunicationDate
 
         Seq(
           (SessionKeys.firstPenaltyChargeReference, firstPenaltyChargeReference),
           (SessionKeys.firstPenaltyAmount, parsedFirstPenaltyAmount),
           (SessionKeys.secondPenaltyChargeReference, secondPenaltyChargeReference),
-          (SessionKeys.secondPenaltyAmount, parsedSecondPenaltyAmount)
+          (SessionKeys.secondPenaltyAmount, parsedSecondPenaltyAmount),
+          (SessionKeys.firstPenaltyCommunicationDate, firstPenaltyCommunicationDate.toString),
+          (SessionKeys.secondPenaltyCommunicationDate, secondPenaltyCommunicationDate.toString)
         )
       }
     }.getOrElse(Seq.empty)

--- a/app/models/appeals/MultiplePenaltiesData.scala
+++ b/app/models/appeals/MultiplePenaltiesData.scala
@@ -18,11 +18,15 @@ package models.appeals
 
 import play.api.libs.json.{Json, Reads}
 
+import java.time.LocalDate
+
 case class MultiplePenaltiesData(
                                   firstPenaltyChargeReference: String,
                                   firstPenaltyAmount: BigDecimal,
                                   secondPenaltyChargeReference: String,
-                                  secondPenaltyAmount: BigDecimal
+                                  secondPenaltyAmount: BigDecimal,
+                                  firstPenaltyCommunicationDate: LocalDate,
+                                  secondPenaltyCommunicationDate: LocalDate
                                 )
 
 object MultiplePenaltiesData {

--- a/app/navigation/Navigation.scala
+++ b/app/navigation/Navigation.scala
@@ -187,7 +187,7 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   def routingForPenaltySelectionPage(answer: Option[String], mode: Mode): Call = {
-    if(answer.get.toLowerCase == "yes") {
+    if (answer.get.toLowerCase == "yes") {
       routes.PenaltySelectionController.onPageLoadForAppealCoverBothPenalties(mode)
     } else {
       routes.PenaltySelectionController.onPageLoadForSinglePenaltySelection(mode)
@@ -233,9 +233,19 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def isAppealLate()(implicit userRequest: UserRequest[_]): Boolean = {
-      val dateNow: LocalDate = dateTimeHelper.dateNow
-      val dateSentParsed: LocalDate = LocalDate.parse(userRequest.session.get(SessionKeys.dateCommunicationSent).get)
-      dateSentParsed.isBefore(dateNow.minusDays(appConfig.daysRequiredForLateAppeal))
+    val dateNow: LocalDate = dateTimeHelper.dateNow
+    userRequest.session.get(SessionKeys.doYouWantToAppealBothPenalties) match {
+      case Some("yes") => {
+        val dateOfFirstComms = LocalDate.parse(userRequest.session.get(SessionKeys.firstPenaltyCommunicationDate).get)
+        val dateOfSecondComms = LocalDate.parse(userRequest.session.get(SessionKeys.secondPenaltyCommunicationDate).get)
+        dateOfFirstComms.isBefore(dateNow.minusDays(appConfig.daysRequiredForLateAppeal)) ||
+          dateOfSecondComms.isBefore(dateNow.minusDays(appConfig.daysRequiredForLateAppeal))
+      }
+      case _ => {
+        val dateOfComms = LocalDate.parse(userRequest.session.get(SessionKeys.dateCommunicationSent).get)
+        dateOfComms.isBefore(dateNow.minusDays(appConfig.daysRequiredForLateAppeal))
+      }
+    }
   }
 
   def routeForUploadList(answer: Option[String], request: UserRequest[_], mode: Mode): Call = {
@@ -270,7 +280,7 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def reverseRouteForAppealStartPage(request: UserRequest[_]): Call = {
-    if(request.session.get(SessionKeys.isObligationAppeal).isDefined) {
+    if (request.session.get(SessionKeys.isObligationAppeal).isDefined) {
       routes.YouCanAppealPenaltyController.onPageLoad()
     } else {
       Call("GET", appConfig.penaltiesFrontendUrl)
@@ -278,7 +288,7 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def reverseRouteForHonestyDeclaration(request: UserRequest[_]): Call = {
-    if(request.session.get(SessionKeys.isObligationAppeal).isDefined) {
+    if (request.session.get(SessionKeys.isObligationAppeal).isDefined) {
       routes.AppealStartController.onPageLoad()
     } else {
       routes.ReasonableExcuseController.onPageLoad()
@@ -286,7 +296,7 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def reverseRouteForUploadEvidenceQuestion(request: UserRequest[_], mode: Mode): Call = {
-    if(request.session.get(SessionKeys.isObligationAppeal).isDefined) {
+    if (request.session.get(SessionKeys.isObligationAppeal).isDefined) {
       routes.AppealAgainstObligationController.onPageLoad(mode)
     } else {
       routes.OtherReasonController.onPageLoadForWhyReturnSubmittedLate(mode)
@@ -310,7 +320,7 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def reverseRoutingForUpload(request: UserRequest[_], mode: Mode): Call = {
-    if(request.session.get(SessionKeys.isUploadEvidence).contains("yes")) {
+    if (request.session.get(SessionKeys.isUploadEvidence).contains("yes")) {
       routes.OtherReasonController.onPageLoadForUploadEvidence(mode)
     } else {
       routes.OtherReasonController.onPageLoadForUploadEvidenceQuestion(mode)
@@ -318,8 +328,8 @@ class Navigation @Inject()(dateTimeHelper: DateTimeHelper,
   }
 
   private def reverseRouteForReasonableExcuseSelectionPage(request: UserRequest[_], mode: Mode): Call = {
-    if(request.isAgent && request.session.get(SessionKeys.appealType).contains(PenaltyTypeEnum.Late_Submission.toString)) {
-      if(request.session.get(SessionKeys.whoPlannedToSubmitVATReturn).contains("agent")) {
+    if (request.isAgent && request.session.get(SessionKeys.appealType).contains(PenaltyTypeEnum.Late_Submission.toString)) {
+      if (request.session.get(SessionKeys.whoPlannedToSubmitVATReturn).contains("agent")) {
         routes.AgentsController.onPageLoadForWhatCausedYouToMissTheDeadline(mode)
       } else {
         routes.AgentsController.onPageLoadForWhoPlannedToSubmitVATReturn(mode)

--- a/app/utils/SessionKeys.scala
+++ b/app/utils/SessionKeys.scala
@@ -59,6 +59,8 @@ object SessionKeys {
   val firstPenaltyAmount = "firstPenaltyAmount"
   val secondPenaltyChargeReference = "secondPenaltyChargeReference"
   val secondPenaltyAmount = "secondPenaltyAmount"
+  val firstPenaltyCommunicationDate = "firstPenaltyCommunicationDate"
+  val secondPenaltyCommunicationDate = "secondPenaltyCommunicationDate"
 
 
   val allKeys: Seq[String] = Seq(
@@ -102,6 +104,8 @@ object SessionKeys {
     firstPenaltyChargeReference,
     firstPenaltyAmount,
     secondPenaltyChargeReference,
-    secondPenaltyAmount
+    secondPenaltyAmount,
+    firstPenaltyCommunicationDate,
+    secondPenaltyCommunicationDate
   )
 }

--- a/app/views/MakingALateAppealPage.scala.html
+++ b/app/views/MakingALateAppealPage.scala.html
@@ -24,19 +24,9 @@
         characterCount: components.characterCount,
         formHelper: FormWithCSRF)
 
-@(form: Form[_], pageMode: PageMode)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(form: Form[_], headingAndTitle: String, pageMode: PageMode)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@areThereMultiplePenaltiesContent = @{
-    if(!request.session.get(SessionKeys.doYouWantToAppealBothPenalties).isDefined) {
-        messages("makingALateAppeal.headingAndTitle")
-    } else if (request.session.get(SessionKeys.doYouWantToAppealBothPenalties).contains("yes")) {
-        messages("makingALateAppeal.headingAndTitle.multi")
-    } else {
-        messages("makingALateAppeal.headingAndTitle.first")
-    }
-}
-
-@layout(pageTitle = areThereMultiplePenaltiesContent,
+@layout(pageTitle = headingAndTitle,
     isPageFullWidth = false,
     formHasErrors = form.errors.nonEmpty,
     formErrors = form.errors,
@@ -45,7 +35,7 @@
     @formHelper(action = controllers.routes.MakingALateAppealController.onSubmit()) {
         @characterCount(
             form("late-appeal-text"),
-            label = areThereMultiplePenaltiesContent,
+            label = headingAndTitle,
             hint = Some(HtmlContent(messages("makingALateAppeal.p1"))),
             maxLength = Some(5000)
         )

--- a/it/connectors/PenaltiesConnectorISpec.scala
+++ b/it/connectors/PenaltiesConnectorISpec.scala
@@ -104,7 +104,9 @@ class PenaltiesConnectorISpec extends IntegrationSpecCommonBase {
         firstPenaltyChargeReference = "123456789",
         firstPenaltyAmount = 101.01,
         secondPenaltyChargeReference = "123456790",
-        secondPenaltyAmount = 101.02
+        secondPenaltyAmount = 101.02,
+        firstPenaltyCommunicationDate = LocalDate.parse("2022-01-01"),
+        secondPenaltyCommunicationDate = LocalDate.parse("2022-01-02")
       )
       val result = await(penaltiesConnector.getMultiplePenaltiesForPrincipleCharge("1234", "HMRC-MTD-VAT~VRN~123456789"))
       result.isRight shouldBe true

--- a/it/controllers/InitialiseAppealControllerISpec.scala
+++ b/it/controllers/InitialiseAppealControllerISpec.scala
@@ -86,7 +86,7 @@ class InitialiseAppealControllerISpec extends IntegrationSpecCommonBase {
         authToken -> "1234"
       )
       successfulGetAppealDataResponse("1234", "HMRC-MTD-VAT~VRN~123456789", isLPP = true, isAdditional = true)
-      successfulGetMultiplePenaltyDetailsResponse("1234", "HMRC-MTD-VAT~VRN~123456789")
+      successfulGetMultiplePenalties("1234", "HMRC-MTD-VAT~VRN~123456789")
       val result = controller.onPageLoad("1234", isLPP = true, isAdditional = true)(fakeRequest)
       await(result).header.status shouldBe SEE_OTHER
       redirectLocation(result).get shouldBe routes.AppealStartController.onPageLoad().url
@@ -99,13 +99,15 @@ class InitialiseAppealControllerISpec extends IntegrationSpecCommonBase {
       await(result).session.get(SessionKeys.journeyId).isDefined shouldBe true
       await(result).session.get(SessionKeys.isObligationAppeal).isDefined shouldBe false
       await(result).session.get(SessionKeys.firstPenaltyAmount).isDefined shouldBe true
-      await(result).session.get(SessionKeys.firstPenaltyAmount).get shouldBe "100.10"
+      await(result).session.get(SessionKeys.firstPenaltyAmount).get shouldBe "101.01"
       await(result).session.get(SessionKeys.secondPenaltyAmount).isDefined shouldBe true
-      await(result).session.get(SessionKeys.secondPenaltyAmount).get shouldBe "302.10"
+      await(result).session.get(SessionKeys.secondPenaltyAmount).get shouldBe "101.02"
       await(result).session.get(SessionKeys.firstPenaltyChargeReference).isDefined shouldBe true
       await(result).session.get(SessionKeys.firstPenaltyChargeReference).get shouldBe "123456789"
       await(result).session.get(SessionKeys.secondPenaltyChargeReference).isDefined shouldBe true
       await(result).session.get(SessionKeys.secondPenaltyChargeReference).get shouldBe "123456790"
+      await(result).session.get(SessionKeys.firstPenaltyCommunicationDate).isDefined shouldBe true
+      await(result).session.get(SessionKeys.firstPenaltyCommunicationDate).get shouldBe "2022-01-01"
     }
 
     "render an ISE when the appeal data can not be retrieved" in {

--- a/it/controllers/PenaltySelectionControllerISpec.scala
+++ b/it/controllers/PenaltySelectionControllerISpec.scala
@@ -44,6 +44,7 @@ class PenaltySelectionControllerISpec extends IntegrationSpecCommonBase with Fea
         (SessionKeys.dateCommunicationSent, "2020-02-08"),
         (SessionKeys.firstPenaltyAmount, "100.01"),
         (SessionKeys.secondPenaltyAmount, "100.02"),
+        (SessionKeys.firstPenaltyCommunicationDate, LocalDate.now().minusDays(30).toString),
         (SessionKeys.journeyId, "1234")
       )
       val request = await(controller.onPageLoadForPenaltySelection(NormalMode)(fakeRequestWithCorrectKeys))
@@ -89,6 +90,7 @@ class PenaltySelectionControllerISpec extends IntegrationSpecCommonBase with Fea
         (SessionKeys.firstPenaltyChargeReference, "123456789"),
         (SessionKeys.secondPenaltyAmount, "100.02"),
         (SessionKeys.secondPenaltyChargeReference, "123456790"),
+        (SessionKeys.firstPenaltyCommunicationDate, LocalDate.now().minusDays(30).toString),
         (SessionKeys.dateCommunicationSent, LocalDate.now().minusDays(20).toString),
         (SessionKeys.journeyId, "1234")
       ).withFormUrlEncodedBody(
@@ -110,6 +112,7 @@ class PenaltySelectionControllerISpec extends IntegrationSpecCommonBase with Fea
         (SessionKeys.dueDateOfPeriod, "2020-02-07"),
         (SessionKeys.firstPenaltyAmount, "100.01"),
         (SessionKeys.secondPenaltyAmount, "100.02"),
+        (SessionKeys.firstPenaltyCommunicationDate, LocalDate.now().minusDays(30).toString),
         (SessionKeys.dateCommunicationSent, LocalDate.now().minusDays(20).toString),
         (SessionKeys.journeyId, "1234")
       ).withFormUrlEncodedBody(

--- a/it/stubs/PenaltiesStub.scala
+++ b/it/stubs/PenaltiesStub.scala
@@ -30,7 +30,6 @@ import scala.collection.JavaConverters
 object PenaltiesStub {
   private val appealUriForLSP = "/penalties/appeals-data/late-submissions"
   private val appealUriForLPP = "/penalties/appeals-data/late-payments"
-  private val appealUriForMultiplePenaltyData = "/penalties/appeals-data/multiple-penalties"
   private val fetchReasonableExcuseUri = "/penalties/appeals-data/reasonable-excuses"
   private val submitAppealUri = "/penalties/appeals/submit-appeal"
   private val submitAppealQueryParams = (isLPP: Boolean, penaltyNumber: String) => Map[String, StringValuePattern](
@@ -70,30 +69,6 @@ object PenaltiesStub {
                 "dueDate" -> LocalDate.of(2020, 2, 7).toString,
                 "dateCommunicationSent" -> LocalDate.of(2020, 2, 8).toString
               ).toString()
-          )
-      )
-    )
-  }
-
-  def successfulGetMultiplePenaltyDetailsResponse(
-                                       penaltyId: String,
-                                       enrolmentKey: String
-                                     ): StubMapping = {
-    stubFor(
-      get(
-        urlEqualTo(
-          s"$appealUriForMultiplePenaltyData?penaltyId=$penaltyId&enrolmentKey=$enrolmentKey"
-        )
-      ).willReturn(
-        aResponse()
-          .withStatus(Status.OK)
-          .withBody(
-            Json.obj(
-              "firstPenaltyChargeReference" -> "123456789",
-              "firstPenaltyAmount" -> "100.10",
-              "secondPenaltyChargeReference" -> "123456790",
-              "secondPenaltyAmount" -> "302.10"
-            ).toString()
           )
       )
     )
@@ -151,7 +126,9 @@ object PenaltiesStub {
                 "firstPenaltyChargeReference" -> "123456789",
                 "firstPenaltyAmount" -> "101.01",
                 "secondPenaltyChargeReference" -> "123456790",
-                "secondPenaltyAmount" -> "101.02"
+                "secondPenaltyAmount" -> "101.02",
+                "firstPenaltyCommunicationDate" -> "2022-01-01",
+                "secondPenaltyCommunicationDate" -> "2022-01-02"
               ).toString()
             )
         )

--- a/test/connectors/PenaltiesConnectorSpec.scala
+++ b/test/connectors/PenaltiesConnectorSpec.scala
@@ -28,6 +28,7 @@ import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import java.time.LocalDate
 
 import java.time.LocalDateTime
 import scala.concurrent.{ExecutionContext, Future}
@@ -110,7 +111,9 @@ class PenaltiesConnectorSpec extends SpecBase {
       | "firstPenaltyChargeReference": "123456789",
       | "firstPenaltyAmount": "101.01",
       | "secondPenaltyChargeReference": "123456790",
-      | "secondPenaltyAmount": "101.02"
+      | "secondPenaltyAmount": "101.02",
+      | "firstPenaltyCommunicationDate" : "2022-01-01",
+      | "firstPenaltyCommunicationDate" : "2022-01-02"
       |}
       |""".stripMargin
   )
@@ -119,7 +122,9 @@ class PenaltiesConnectorSpec extends SpecBase {
     firstPenaltyChargeReference = "123456789",
     firstPenaltyAmount = 101.01,
     secondPenaltyChargeReference = "123456790",
-    secondPenaltyAmount = 101.02
+    secondPenaltyAmount = 101.02,
+    firstPenaltyCommunicationDate = LocalDate.of(2022, 1, 1),
+    secondPenaltyCommunicationDate = LocalDate.of(2022, 1, 2)
   )
 
   class Setup {

--- a/test/connectors/httpParsers/MultiplePenaltiesHttpParserSpec.scala
+++ b/test/connectors/httpParsers/MultiplePenaltiesHttpParserSpec.scala
@@ -22,13 +22,17 @@ import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.HttpResponse
 
+import java.time.LocalDate
+
 class MultiplePenaltiesHttpParserSpec extends SpecBase {
 
   val multiplePenaltiesModel: MultiplePenaltiesData = MultiplePenaltiesData(
     firstPenaltyChargeReference = "123456789",
     firstPenaltyAmount = 101.01,
     secondPenaltyChargeReference = "123456790",
-    secondPenaltyAmount = 101.02
+    secondPenaltyAmount = 101.02,
+    firstPenaltyCommunicationDate = LocalDate.of(2022, 1, 1),
+    secondPenaltyCommunicationDate = LocalDate.of(2022, 1, 2)
   )
 
   val multiplePenaltiesJson: JsValue = Json.parse(
@@ -37,7 +41,9 @@ class MultiplePenaltiesHttpParserSpec extends SpecBase {
       | "firstPenaltyChargeReference": "123456789",
       | "firstPenaltyAmount": 101.01,
       | "secondPenaltyChargeReference": "123456790",
-      | "secondPenaltyAmount": 101.02
+      | "secondPenaltyAmount": 101.02,
+      | "firstPenaltyCommunicationDate": "2022-01-01",
+      | "secondPenaltyCommunicationDate": "2022-01-02"
       |}
       |""".stripMargin)
 

--- a/test/controllers/InitialiseAppealControllerSpec.scala
+++ b/test/controllers/InitialiseAppealControllerSpec.scala
@@ -53,7 +53,9 @@ class InitialiseAppealControllerSpec extends SpecBase {
     firstPenaltyChargeReference = "123456789",
     firstPenaltyAmount = 101.01,
     secondPenaltyChargeReference = "123456790",
-    secondPenaltyAmount = 101.02
+    secondPenaltyAmount = 101.02,
+    firstPenaltyCommunicationDate = LocalDate.of(2022, 1, 1),
+    secondPenaltyCommunicationDate = LocalDate.of(2022, 1, 2)
   )
 
   "onPageLoad" should {

--- a/test/models/appeals/MultiplePenaltiesDataSpec.scala
+++ b/test/models/appeals/MultiplePenaltiesDataSpec.scala
@@ -19,6 +19,7 @@ package models.appeals
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
+import java.time.LocalDate
 
 class MultiplePenaltiesDataSpec extends AnyWordSpec with Matchers {
 
@@ -30,7 +31,9 @@ class MultiplePenaltiesDataSpec extends AnyWordSpec with Matchers {
           | "firstPenaltyChargeReference": "123456789",
           | "firstPenaltyAmount": 101.01,
           | "secondPenaltyChargeReference": "123456790",
-          | "secondPenaltyAmount": 101.02
+          | "secondPenaltyAmount": 101.02,
+          | "firstPenaltyCommunicationDate" : "2022-01-01",
+          | "secondPenaltyCommunicationDate" : "2022-01-02"
           |}
           |""".stripMargin
       )
@@ -39,7 +42,9 @@ class MultiplePenaltiesDataSpec extends AnyWordSpec with Matchers {
         firstPenaltyChargeReference = "123456789",
         firstPenaltyAmount = 101.01,
         secondPenaltyChargeReference = "123456790",
-        secondPenaltyAmount = 101.02
+        secondPenaltyAmount = 101.02,
+        firstPenaltyCommunicationDate = LocalDate.parse("2022-01-01"),
+        secondPenaltyCommunicationDate = LocalDate.parse("2022-01-02")
       )
       val result = Json.fromJson(multiplePenaltiesJson)(MultiplePenaltiesData.format)
       result.isSuccess shouldBe true

--- a/test/navigation/NavigationSpec.scala
+++ b/test/navigation/NavigationSpec.scala
@@ -882,6 +882,36 @@ class NavigationSpec extends SpecBase {
         result.url shouldBe controllers.routes.MakingALateAppealController.onPageLoad().url
       }
 
+      "appealing multiple penalties and the LPP1 communication date is more than 30 days ago" in new Setup {
+        when(mockDateTimeHelper.dateNow).thenReturn(LocalDate.of(2020, 4, 1))
+
+        val result: Call = mainNavigator.routeToMakingALateAppealOrCYAPage(fakeRequestConverter(fakeRequestWithCorrectKeys
+          .withSession(
+            SessionKeys.appealType -> "crime",
+            SessionKeys.firstPenaltyCommunicationDate -> "2020-02-01",
+            SessionKeys.secondPenaltyCommunicationDate -> "2020-03-31",
+            SessionKeys.dateCommunicationSent -> "",
+            SessionKeys.doYouWantToAppealBothPenalties -> "yes"
+          )), NormalMode)
+
+        result.url shouldBe controllers.routes.MakingALateAppealController.onPageLoad().url
+      }
+
+      "appealing multiple penalties and both the LPP1 / LPP2 communication date are more than 30 days ago" in new Setup {
+        when(mockDateTimeHelper.dateNow).thenReturn(LocalDate.of(2020, 4, 1))
+
+        val result: Call = mainNavigator.routeToMakingALateAppealOrCYAPage(fakeRequestConverter(fakeRequestWithCorrectKeys
+          .withSession(
+            SessionKeys.appealType -> "crime",
+            SessionKeys.firstPenaltyCommunicationDate -> "2020-02-01",
+            SessionKeys.secondPenaltyCommunicationDate -> "2020-02-28",
+            SessionKeys.dateCommunicationSent -> "",
+            SessionKeys.doYouWantToAppealBothPenalties -> "yes"
+          )), NormalMode)
+
+        result.url shouldBe controllers.routes.MakingALateAppealController.onPageLoad().url
+      }
+
       "the appeal is late but the reason has already been given and we are in NormalMode" in new Setup {
         when(mockDateTimeHelper.dateNow).thenReturn(LocalDate.of(2020, 4, 1))
 

--- a/test/services/AppealServiceSpec.scala
+++ b/test/services/AppealServiceSpec.scala
@@ -32,6 +32,7 @@ import play.api.test.Helpers._
 import services.monitoring.JsonAuditModel
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.{SessionKeys, UUIDGenerator}
+import java.time.LocalDate
 
 import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.{ExecutionContext, Future}
@@ -106,7 +107,9 @@ class AppealServiceSpec extends SpecBase {
     firstPenaltyChargeReference = "123456789",
     firstPenaltyAmount = 101.01,
     secondPenaltyChargeReference = "123456790",
-    secondPenaltyAmount = 101.02
+    secondPenaltyAmount = 101.02,
+    firstPenaltyCommunicationDate = LocalDate.parse("2022-01-01"),
+    secondPenaltyCommunicationDate = LocalDate.parse("2022-01-02"),
   )
 
   class Setup {

--- a/test/views/MakingALateAppealPageSpec.scala
+++ b/test/views/MakingALateAppealPageSpec.scala
@@ -33,7 +33,8 @@ class MakingALateAppealPageSpec extends SpecBase with ViewBehaviours {
     val makingALateAppealPage: MakingALateAppealPage = injector.instanceOf[MakingALateAppealPage]
     object Selectors extends BaseSelectors
     "when a single penalty is appealed" when {
-      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form, pageMode = PageMode(MakingALateAppealPage, NormalMode))
+      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form,
+        "This penalty was issued more than 30 days ago", pageMode = PageMode(MakingALateAppealPage, NormalMode))
 
       val formProvider = MakingALateAppealForm.makingALateAppealForm()
       implicit val doc: Document = asDocument(applyView(formProvider))
@@ -49,7 +50,7 @@ class MakingALateAppealPageSpec extends SpecBase with ViewBehaviours {
     }
 
     "when multiple penalties are being appealed" when {
-      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form,
+      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form, "The penalties were issued more than 30 days ago",
         pageMode = PageMode(MakingALateAppealPage, NormalMode))(fakeRequestWithCorrectKeys.withSession(SessionKeys.doYouWantToAppealBothPenalties -> "yes"), messages, appConfig)
 
       val formProvider = MakingALateAppealForm.makingALateAppealForm()
@@ -65,9 +66,9 @@ class MakingALateAppealPageSpec extends SpecBase with ViewBehaviours {
       behave like pageWithExpectedMessages(expectedContent)
     }
 
-    "when only one penalty of the period is being appealed" when {
-      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form,
-        pageMode = PageMode(MakingALateAppealPage, NormalMode))(fakeRequestWithCorrectKeys.withSession(SessionKeys.doYouWantToAppealBothPenalties -> "no"), messages, appConfig)
+    "when multiple penalties are being appealed - and the first penalty is late" when {
+      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form, "The first penalty was issued more than 30 days ago",
+        pageMode = PageMode(MakingALateAppealPage, NormalMode))(fakeRequestWithCorrectKeys.withSession(SessionKeys.doYouWantToAppealBothPenalties -> "yes"), messages, appConfig)
 
       val formProvider = MakingALateAppealForm.makingALateAppealForm()
       implicit val doc: Document = asDocument(applyView(formProvider))
@@ -75,6 +76,23 @@ class MakingALateAppealPageSpec extends SpecBase with ViewBehaviours {
       val expectedContent = Seq(
         Selectors.title -> titleFirst,
         Selectors.h1 -> headingFirst,
+        Selectors.hintText -> hintText,
+        Selectors.button -> continueBtn
+      )
+
+      behave like pageWithExpectedMessages(expectedContent)
+    }
+
+    "when only one penalty of the period is being appealed" when {
+      def applyView(form: Form[_]): HtmlFormat.Appendable = makingALateAppealPage.apply(form, "This penalty was issued more than 30 days ago",
+        pageMode = PageMode(MakingALateAppealPage, NormalMode))(fakeRequestWithCorrectKeys.withSession(SessionKeys.doYouWantToAppealBothPenalties -> "no"), messages, appConfig)
+
+      val formProvider = MakingALateAppealForm.makingALateAppealForm()
+      implicit val doc: Document = asDocument(applyView(formProvider))
+
+      val expectedContent = Seq(
+        Selectors.title -> title,
+        Selectors.h1 -> heading,
         Selectors.hintText -> hintText,
         Selectors.button -> continueBtn
       )


### PR DESCRIPTION
Both penalties late:
![both-penalties-late](https://user-images.githubusercontent.com/53828896/181492088-e4752037-3121-4d95-b42e-4714d05a5e09.png)
No multiple appeal:
![no-multiple-appeal](https://user-images.githubusercontent.com/53828896/181492078-85f7d529-7dd1-452d-8537-326652d199b8.png)
Only lpp1 is late:
![lpp1-is-late](https://user-images.githubusercontent.com/53828896/181492086-c281ffd1-9be3-47e2-bb70-cbbe1634ef43.png)
