### PR TITLE
[PRM-2561] - Introduce new feature switch for audits

### DIFF
--- a/app/config/featureSwitches/FeatureSwitch.scala
+++ b/app/config/featureSwitches/FeatureSwitch.scala
@@ -23,7 +23,7 @@ sealed trait FeatureSwitch {
 
 object FeatureSwitch {
   val prefix: String = "feature.switch"
-  val listOfAllFeatureSwitches: List[FeatureSwitch] = List(NonJSRouting, ShowDigitalCommsMessage, WarnForDuplicateFiles, ShowFullAppealAgainstTheObligation)
+  val listOfAllFeatureSwitches: List[FeatureSwitch] = List(NonJSRouting, ShowDigitalCommsMessage, WarnForDuplicateFiles, ShowFullAppealAgainstTheObligation, UseNewAuditStructure)
 }
 
 case object NonJSRouting extends FeatureSwitch {
@@ -44,4 +44,9 @@ case object WarnForDuplicateFiles extends FeatureSwitch {
 case object ShowFullAppealAgainstTheObligation extends FeatureSwitch {
   override val name: String = s"${FeatureSwitch.prefix}.show-full-appeal-against-the-obligation-journey"
   override val displayText: String = "To show the full appeal against the obligation journey"
+}
+
+case object UseNewAuditStructure extends FeatureSwitch {
+  override val name: String = s"${FeatureSwitch.prefix}.use-new-audit-structure"
+  override val displayText: String = "Use the audit structure that has not been approved for use in Production"
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -148,6 +148,7 @@ feature {
     time-machine-now = ""
     warn-for-duplicate-files = false
     show-full-appeal-against-the-obligation-journey = true
+    use-new-audit-structure = true
   }
 }
 

--- a/test/config/featureSwitches/FeatureSwitchingSpec.scala
+++ b/test/config/featureSwitches/FeatureSwitchingSpec.scala
@@ -36,6 +36,7 @@ class FeatureSwitchingSpec extends SpecBase {
     sys.props -= ShowDigitalCommsMessage.name
     sys.props -= WarnForDuplicateFiles.name
     sys.props -= ShowFullAppealAgainstTheObligation.name
+    sys.props -= UseNewAuditStructure.name
     sys.props -= featureSwitching.TIME_MACHINE_NOW
   }
 
@@ -45,11 +46,12 @@ class FeatureSwitchingSpec extends SpecBase {
     sys.props -= ShowDigitalCommsMessage.name
     sys.props -= WarnForDuplicateFiles.name
     sys.props -= ShowFullAppealAgainstTheObligation.name
+    sys.props -= UseNewAuditStructure.name
   }
 
   "listOfAllFeatureSwitches" should {
     "be all the featureswitches in the app" in {
-      FeatureSwitch.listOfAllFeatureSwitches shouldBe List(NonJSRouting, ShowDigitalCommsMessage, WarnForDuplicateFiles, ShowFullAppealAgainstTheObligation)
+      FeatureSwitch.listOfAllFeatureSwitches shouldBe List(NonJSRouting, ShowDigitalCommsMessage, WarnForDuplicateFiles, ShowFullAppealAgainstTheObligation, UseNewAuditStructure)
     }
   }
 


### PR DESCRIPTION
Unit spec automatically picks up new entries in the feature switch list to save duplication of same test for different feature switches: 
https://github.com/hmrc/penalties-appeals-frontend/blob/28d066ee11ad32bd177cbd517dc833945d0048f8/test/config/featureSwitches/FeatureSwitchingSpec.scala#L84