### PR TITLE
[PRM-2740] - Added check for journey ID in data retrieval action

### DIFF
--- a/app/controllers/IncompleteSessionDataController.scala
+++ b/app/controllers/IncompleteSessionDataController.scala
@@ -24,11 +24,12 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.SessionKeys
-import views.html.errors.IncompleteSessionDataPage
+import views.html.errors.{IncompleteSessionDataPage, NoSessionDataPage}
 
 import javax.inject.Inject
 
-class IncompleteSessionDataController @Inject()(incompleteSessionDataPage: IncompleteSessionDataPage)
+class IncompleteSessionDataController @Inject()(incompleteSessionDataPage: IncompleteSessionDataPage,
+                                                noSessionDataPage: NoSessionDataPage)
                                                (implicit mcc: MessagesControllerComponents,
                                                 appConfig: AppConfig,
                                                 authorise: AuthPredicate,
@@ -42,6 +43,12 @@ class IncompleteSessionDataController @Inject()(incompleteSessionDataPage: Incom
       val isLPP = request.answers.getAnswer[PenaltyTypeEnum.Value](SessionKeys.appealType).contains(Late_Payment)
       val isAdditional = request.answers.getAnswer[PenaltyTypeEnum.Value](SessionKeys.appealType).contains(Additional)
       BadRequest(incompleteSessionDataPage(penaltyId, isLPP, isAdditional))
+    }
+  }
+
+  def onPageLoadWithNoJourneyData(): Action[AnyContent] = authorise {
+    implicit request => {
+      BadRequest(noSessionDataPage())
     }
   }
 }

--- a/app/models/AuthRequest.scala
+++ b/app/models/AuthRequest.scala
@@ -25,7 +25,6 @@ case class AuthRequest[A](vrn: String,
                           arn: Option[String] = None
                          )(implicit request: Request[A]) extends WrappedRequest[A](request) {
   val isAgent: Boolean = arn.isDefined
-  val redirectSuffix: String = if (isAgent) "agent" else "non-agent"
 }
 
 object AuthRequest {

--- a/app/views/errors/NoSessionDataPage.scala.html
+++ b/app/views/errors/NoSessionDataPage.scala.html
@@ -1,0 +1,42 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        layout: Layout,
+        link: components.link,
+        pageHeader: components.pageHeader
+)
+
+@()(implicit messages: Messages, appConfig: AppConfig, user: AuthRequest[_])
+
+@layout(
+  pageTitle = messages("incompleteSessionData.headingAndTitle"),
+  isPageFullWidth = false,
+  backLinkEnabled = false
+) {
+  <h1 class="govuk-heading-l" id="page-heading">@messages("incompleteSessionData.headingAndTitle")</h1>
+
+  <p class="govuk-body">@messages("incompleteSessionData.p1")</p>
+
+  <p class="govuk-body">
+    @link(
+      link = appConfig.penaltiesFrontendUrl,
+      messageKey = if(user.isAgent) "agent.common.returnToPenalties" else "common.returnToPenalties",
+      button = false,
+      id = Some("penalties-link")
+    )
+  </p>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -202,6 +202,7 @@ GET        /appeal-single-penalty/change                       controllers.Penal
 
 # Incomplete session data
 GET        /incomplete-answers                                 controllers.IncompleteSessionDataController.onPageLoad()
+GET        /invalid-session                                    controllers.IncompleteSessionDataController.onPageLoadWithNoJourneyData()
 
 # Appeal by letter
 GET        /appeal-by-letter                                   controllers.YouCannotAppealController.onPageLoadAppealByLetter()

--- a/test/assets/messages/IncompleteSessionDataMessages.scala
+++ b/test/assets/messages/IncompleteSessionDataMessages.scala
@@ -24,4 +24,8 @@ object IncompleteSessionDataMessages {
   val p1 = "There’s been a technical error. You need to start your appeal again. We have not saved your data."
 
   val link = "Return to the appeal start page"
+
+  val linkBackToPenaltiesTrader = "Return to your VAT penalties"
+
+  val linkBackToPenaltiesAgent = "Return to your client’s VAT penalties"
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -86,7 +86,7 @@ trait SpecBase extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with B
 
   lazy val checkObligationAvailabilityAction: CheckObligationAvailabilityActionImpl = new CheckObligationAvailabilityActionImpl(mockAppConfig)
 
-  lazy val dataRetrievalAction: DataRetrievalActionImpl = new DataRetrievalActionImpl(mockSessionService)
+  lazy val dataRetrievalAction: DataRetrievalActionImpl = new DataRetrievalActionImpl(mockSessionService, errorHandler)
 
   val mockAuthService: AuthService = new AuthService(mockAuthConnector)
 

--- a/test/controllers/predicates/DataRequiredActionSpec.scala
+++ b/test/controllers/predicates/DataRequiredActionSpec.scala
@@ -42,12 +42,12 @@ class DataRequiredActionSpec extends SpecBase {
 
   "refine" should {
     s"show an ISE (${Status.INTERNAL_SERVER_ERROR}) when all of the data is missing as part of the session" in {
-      val requestWithNoSessionKeys = UserRequest("123456789", answers = userAnswers(Json.obj()))
-      val fakeController = new Harness(
-        requiredAction = new DataRequiredActionImpl(
-          errorHandler
-        ),
-        request = requestWithNoSessionKeys)
+        val requestWithNoSessionKeys = UserRequest("123456789", answers = userAnswers(Json.obj()))
+        val fakeController = new Harness(
+          requiredAction = new DataRequiredActionImpl(
+            errorHandler
+          ),
+          request = requestWithNoSessionKeys)
 
       val result = await(fakeController.onPageLoad())
       result.header.status shouldBe INTERNAL_SERVER_ERROR

--- a/test/controllers/predicates/DataRetrievalActionSpec.scala
+++ b/test/controllers/predicates/DataRetrievalActionSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import base.SpecBase
+import models.AuthRequest
+import models.session.UserAnswers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import play.api.mvc.Results.Ok
+import play.api.mvc.{Request, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import utils.SessionKeys
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DataRetrievalActionSpec extends SpecBase {
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  val testAction: Request[_] => Future[Result] = _ => Future.successful(Ok(""))
+
+  class Harness(retrievalAction: DataRetrievalAction, request: AuthRequest[_] = AuthRequest("123456789",
+    active = true, None)(fakeRequest)) {
+    def onPageLoad(): Future[Result] = retrievalAction.invokeBlock(request, testAction)
+  }
+
+  "refine" should {
+    "return OK" when {
+      "there is a 'penaltiesHasSeenConfirmationPage' session key" in {
+        when(mockSessionService.getUserAnswers(any())).thenReturn(Future.successful(Some(UserAnswers("1234"))))
+        val requestWithNoSessionKeys = AuthRequest("123456789")(fakeRequest.withSession(SessionKeys.penaltiesHasSeenConfirmationPage -> "true"))
+        val fakeController = new Harness(
+          retrievalAction = new DataRetrievalActionImpl(
+            mockSessionService,
+            errorHandler
+          ),
+          request = requestWithNoSessionKeys)
+        val result = fakeController.onPageLoad()
+        status(result) shouldBe OK
+      }
+
+      "there is no session data" in {
+        when(mockSessionService.getUserAnswers(any())).thenReturn(Future.successful(None))
+        val requestWithNoSessionKeys = AuthRequest("123456789")(fakeRequest)
+        val fakeController = new Harness(
+          retrievalAction = new DataRetrievalActionImpl(
+            mockSessionService,
+            errorHandler
+          ),
+          request = requestWithNoSessionKeys)
+        val result = fakeController.onPageLoad()
+        status(result) shouldBe OK
+      }
+    }
+
+    "navigate to the incomplete session data page" when {
+      "no journey ID is in the session" in {
+        val requestWithNoSessionKeys = AuthRequest("123456789")(FakeRequest("GET", "/"))
+        val fakeController = new Harness(
+          retrievalAction = new DataRetrievalActionImpl(
+            mockSessionService,
+            errorHandler
+          ),
+          request = requestWithNoSessionKeys)
+        val result = fakeController.onPageLoad()
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result).get shouldBe controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData().url
+      }
+    }
+
+    "render an ISE" when {
+      "data cannot be retrieved from the session service" in {
+        when(mockSessionService.getUserAnswers(any())).thenReturn(Future.failed(new Exception("I broke!")))
+        val fakeController = new Harness(
+          retrievalAction = new DataRetrievalActionImpl(
+            mockSessionService,
+            errorHandler
+          ))
+        val result = fakeController.onPageLoad()
+        status(result) shouldBe INTERNAL_SERVER_ERROR
+      }
+    }
+  }
+
+}

--- a/test/views/NoSessionDataPageSpec.scala
+++ b/test/views/NoSessionDataPageSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.{BaseSelectors, SpecBase}
+import messages.IncompleteSessionDataMessages._
+import models.AuthRequest
+import org.jsoup.nodes.Document
+import play.twirl.api.Html
+import views.behaviours.ViewBehaviours
+import views.html.errors.NoSessionDataPage
+
+class NoSessionDataPageSpec extends SpecBase with ViewBehaviours {
+  val noSessionDataPage: NoSessionDataPage = injector.instanceOf[NoSessionDataPage]
+
+  object Selectors extends BaseSelectors {
+    val link = "#penalties-link"
+  }
+
+  def applyView(authRequest: AuthRequest[_]): Html = noSessionDataPage()(implicitly, implicitly, authRequest)
+
+  implicit val doc: Document = asDocument(applyView(AuthRequest("123456789")))
+
+  "NoSessionDataPage" should {
+    val expectedContent = Seq(
+      Selectors.title -> title,
+      Selectors.h1 -> heading,
+      Selectors.pElementIndex(2) -> p1,
+      Selectors.link -> linkBackToPenaltiesTrader
+    )
+
+    behave like pageWithExpectedMessages(expectedContent)
+
+    "have the correct link when the user is an agent" in {
+      val doc: Document = asDocument(applyView(AuthRequest("123456789", arn = Some("ARN123"))))
+      doc.select(Selectors.link).text() shouldBe linkBackToPenaltiesAgent
+    }
+  }
+
+}


### PR DESCRIPTION
![image](https://github.com/hmrc/penalties-appeals-frontend/assets/53828896/306413a9-6f1a-4442-92b5-34c6d24fea2d)
