### PR TITLE
[PRM-2851] - Kept data in session post-appeal

### DIFF
--- a/app/controllers/AppealConfirmationController.scala
+++ b/app/controllers/AppealConfirmationController.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import config.featureSwitches.{FeatureSwitching, ShowDigitalCommsMessage}
+import controllers.predicates.AuthPredicate
+import models.PenaltyTypeEnum
+import play.api.Configuration
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import utils.Logger.logger
+import utils.SessionKeys
+import views.html.AppealConfirmationPage
+import viewtils.ImplicitDateFormatter
+
+import java.time.LocalDate
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AppealConfirmationController @Inject()(
+                                              sessionService: SessionService,
+                                              appealConfirmationPage: AppealConfirmationPage
+                                            )(implicit ec: ExecutionContext,
+                                              val config: Configuration,
+                                              appConfig: AppConfig,
+                                              mcc: MessagesControllerComponents,
+                                              authorise: AuthPredicate) extends FrontendController(mcc) with I18nSupport with ImplicitDateFormatter with FeatureSwitching {
+  def onPageLoad(): Action[AnyContent] = authorise.async {
+    implicit request => {
+      request.session.get(SessionKeys.previouslySubmittedJourneyId).fold({
+        logger.warn(s"[AppealConfirmationController][onPageLoad] - No journey ID was found in the session for VRN: ${request.vrn} - " +
+          s"redirecting to incomplete session data page")
+        Future(Redirect(controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData()))
+      })(
+        journeyId => {
+          sessionService.getUserAnswers(journeyId).map {
+            userAnswers => {
+              userAnswers.fold({
+                logger.warn(s"[AppealConfirmationController][onPageLoad] - No submitted user answers were found in the session for VRN: ${request.vrn} - " +
+                  s"redirecting to incomplete session data page")
+                Redirect(controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData())
+              })(
+                userAnswers => {
+                  val appealType = userAnswers.getAnswer[PenaltyTypeEnum.Value](SessionKeys.appealType).get
+                  val bothPenalties: String = userAnswers.getAnswer[String](SessionKeys.doYouWantToAppealBothPenalties).getOrElse("no")
+                  val startDate: LocalDate = userAnswers.getAnswer[LocalDate](SessionKeys.startDateOfPeriod).get
+                  val endDate: LocalDate = userAnswers.getAnswer[LocalDate](SessionKeys.endDateOfPeriod).get
+                  val (readablePeriodStart, readablePeriodEnd) = (dateToString(startDate), dateToString(endDate))
+                  val isObligationAppeal: Boolean = userAnswers.getAnswer[Boolean](SessionKeys.isObligationAppeal).contains(true)
+                  val showDigitalCommsMessage: Boolean = isEnabled(ShowDigitalCommsMessage)
+                  val isAgent: Boolean = request.isAgent
+                  val vrn = request.vrn
+                  Ok(appealConfirmationPage(readablePeriodStart, readablePeriodEnd, isObligationAppeal, showDigitalCommsMessage, appealType, bothPenalties, isAgent, vrn))
+                    .removingFromSession(SessionKeys.allKeys: _*)
+                }
+              )
+            }
+          }
+        })
+    }
+  }
+}

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -16,32 +16,28 @@
 
 package controllers
 
-import config.featureSwitches.{FeatureSwitching, ShowDigitalCommsMessage}
+import config.featureSwitches.FeatureSwitching
 import config.{AppConfig, ErrorHandler}
 import controllers.predicates.{AuthPredicate, CheckObligationAvailabilityAction, DataRequiredAction, DataRetrievalAction}
 import helpers.{IsLateAppealHelper, SessionAnswersHelper}
 import models.pages.{CheckYourAnswersPage, PageMode}
-import models.{Mode, NormalMode, PenaltyTypeEnum, UserRequest}
+import models.{Mode, NormalMode, UserRequest}
 import play.api.Configuration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import repositories.UploadJourneyRepository
-import services.{AppealService, SessionService}
+import services.AppealService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.Logger.logger
 import utils.SessionKeys
-import views.html.{AppealConfirmationPage, CheckYourAnswersPage}
+import views.html.CheckYourAnswersPage
 import viewtils.ImplicitDateFormatter
 
-import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CheckYourAnswersController @Inject()(checkYourAnswersPage: CheckYourAnswersPage,
                                            appealService: AppealService,
-                                           appealConfirmationPage: AppealConfirmationPage,
                                            errorHandler: ErrorHandler,
-                                           sessionService: SessionService,
                                            sessionAnswersHelper: SessionAnswersHelper,
                                            isLateAppealHelper: IsLateAppealHelper)
                                           (implicit mcc: MessagesControllerComponents,
@@ -128,47 +124,12 @@ class CheckYourAnswersController @Inject()(checkYourAnswersPage: CheckYourAnswer
       },
       _ => {
         val previouslySubmittedJourneyId = userRequest.answers.journeyId
-        Future(Redirect(controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation()).addingToSession(
+        Future(Redirect(controllers.routes.AppealConfirmationController.onPageLoad()).addingToSession(
           SessionKeys.previouslySubmittedJourneyId -> previouslySubmittedJourneyId,
           SessionKeys.penaltiesHasSeenConfirmationPage -> "true"
         ))
       }
     ))
-  }
-
-  def onPageLoadForConfirmation(): Action[AnyContent] = authorise.async {
-    implicit request => {
-      request.session.get(SessionKeys.previouslySubmittedJourneyId).fold({
-        logger.warn(s"[CheckYourAnswersController][onPageLoadForConfirmation] - No journey ID was found in the session for VRN: ${request.vrn} - " +
-          s"redirecting to incomplete session data page")
-        Future(Redirect(controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData()))
-      })(
-        journeyId => {
-          sessionService.getUserAnswers(journeyId).map {
-            userAnswers => {
-              userAnswers.fold({
-                logger.warn(s"[CheckYourAnswersController][onPageLoadForConfirmation] - No submitted user answers were found in the session for VRN: ${request.vrn} - " +
-                  s"redirecting to incomplete session data page")
-                Redirect(controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData())
-              })(
-                userAnswers => {
-                  val appealType = userAnswers.getAnswer[PenaltyTypeEnum.Value](SessionKeys.appealType).get
-                  val bothPenalties: String = userAnswers.getAnswer[String](SessionKeys.doYouWantToAppealBothPenalties).getOrElse("no")
-                  val startDate: LocalDate = userAnswers.getAnswer[LocalDate](SessionKeys.startDateOfPeriod).get
-                  val endDate: LocalDate = userAnswers.getAnswer[LocalDate](SessionKeys.endDateOfPeriod).get
-                  val (readablePeriodStart, readablePeriodEnd) = (dateToString(startDate), dateToString(endDate))
-                  val isObligationAppeal: Boolean = userAnswers.getAnswer[Boolean](SessionKeys.isObligationAppeal).contains(true)
-                  val showDigitalCommsMessage: Boolean = isEnabled(ShowDigitalCommsMessage)
-                  val isAgent: Boolean = request.isAgent
-                  val vrn = request.vrn
-                  Ok(appealConfirmationPage(readablePeriodStart, readablePeriodEnd, isObligationAppeal, showDigitalCommsMessage, appealType, bothPenalties, isAgent, vrn))
-                    .removingFromSession(SessionKeys.allKeys: _*)
-                }
-              )
-            }
-          }
-        })
-    }
   }
 
   def changeAnswer(continueUrl: String, pageName: String): Action[AnyContent] = (authorise andThen dataRetrieval andThen dataRequired) {

--- a/app/controllers/predicates/DataRequiredAction.scala
+++ b/app/controllers/predicates/DataRequiredAction.scala
@@ -40,11 +40,11 @@ class DataRequiredActionImpl @Inject()(errorHandler: ErrorHandler)(implicit val 
       request.answers.getAnswer[String](SessionKeys.dateCommunicationSent),
       request.session.get(SessionKeys.journeyId),
       request.session.get(SessionKeys.penaltiesHasSeenConfirmationPage)) match {
-      case (Some(_), Some(_), Some(_), Some(_), Some(_), Some(_), Some(_), _) =>
-        Future.successful(Right(request))
-      case (None, None, None, None, None, None, None, Some(_)) =>
+      case (_, _, _, _, _, _, Some(_), Some(_)) =>
         logger.info("[DataRequiredAction] - User has 'penaltiesHasSeenConfirmationPage' session key in session, routing to 'You cannot go back to appeal details page'")
         Future.successful(Left(Redirect(controllers.routes.YouCannotGoBackToAppealController.onPageLoad())))
+      case (Some(_), Some(_), Some(_), Some(_), Some(_), Some(_), Some(_), _) =>
+        Future.successful(Right(request))
       case _ =>
         logger.error("[DataRequiredAction][refine] - Some data was missing from the session - rendering ISE")
         logger.debug(s"[DataRequiredAction][refine] - Required data from session: ${

--- a/app/repositories/UploadJourneyRepository.scala
+++ b/app/repositories/UploadJourneyRepository.scala
@@ -132,11 +132,6 @@ class UploadJourneyRepository @Inject()(
     }
   }
 
-  def removeUploadsForJourney(journeyId: String): Future[Unit] = {
-    logger.info(s"[UploadJourneyRepository][removeUploadsForJourney] - Removing uploads for journey ID: $journeyId")
-    deleteEntity(journeyId)
-  }
-
   def removeFileForJourney(journeyId: String, fileReference: String): Future[Unit] = {
     getNumberOfDocumentsForJourneyId(journeyId).map {
       amountOfDocuments => {

--- a/app/repositories/UserAnswersRepository.scala
+++ b/app/repositories/UserAnswersRepository.scala
@@ -74,15 +74,4 @@ class UserAnswersRepository @Inject()(mongo: MongoComponent,
         }
       }
   }
-
-  def deleteUserAnswers(journeyId: String): Future[Int] = {
-    collection.deleteOne(equal("journeyId", journeyId)).toFuture().map(_.getDeletedCount.toInt)
-      .recover {
-        case e => {
-          logger.error(s"[UserAnswersRepository][deleteUserAnswers] - Failed to delete data for journeyId: $journeyId with " +
-            s"error message: ${e.getMessage}")
-          0
-        }
-      }
-  }
 }

--- a/app/utils/SessionKeys.scala
+++ b/app/utils/SessionKeys.scala
@@ -17,16 +17,16 @@
 package utils
 
 object SessionKeys {
-  val appealType: String = "appealType"
-  val startDateOfPeriod: String = "periodStart"
-  val endDateOfPeriod: String = "periodEnd"
-  val dueDateOfPeriod: String = "periodDueDate"
-  val dateCommunicationSent: String = "dateCommunicationSent"
-  val penaltyNumber: String = "penaltyNumber"
-  val reasonableExcuse: String = "reasonableExcuse"
-  val dateOfCrime: String = "dateOfCrime"
-  val dateOfFireOrFlood: String = "dateOfFireOrFlood"
-  val hasConfirmedDeclaration: String = "hasConfirmedDeclaration"
+  val appealType = "appealType"
+  val startDateOfPeriod = "periodStart"
+  val endDateOfPeriod = "periodEnd"
+  val dueDateOfPeriod = "periodDueDate"
+  val dateCommunicationSent = "dateCommunicationSent"
+  val penaltyNumber = "penaltyNumber"
+  val reasonableExcuse = "reasonableExcuse"
+  val dateOfCrime = "dateOfCrime"
+  val dateOfFireOrFlood = "dateOfFireOrFlood"
+  val hasConfirmedDeclaration = "hasConfirmedDeclaration"
   val hasCrimeBeenReportedToPolice = "hasCrimeBeenReportedToPolice"
   val lateAppealReason = "lateAppealReason"
   val whenPersonLeftTheBusiness = "whenPersonLeftTheBusiness"
@@ -61,14 +61,9 @@ object SessionKeys {
   val secondPenaltyAmount = "secondPenaltyAmount"
   val firstPenaltyCommunicationDate = "firstPenaltyCommunicationDate"
   val secondPenaltyCommunicationDate = "secondPenaltyCommunicationDate"
-  val confirmationAppealType = "confirmationAppealType"
-  val confirmationStartDate = "confirmationStartDate"
-  val confirmationEndDate = "confirmationEndDate"
-  val confirmationObligation = "confirmationObligation"
-  val confirmationDigitalComms = "confirmationDigitalComms"
-  val confirmationMultipleAppeals = "confirmationMultipleAppeals"
-  val confirmationIsAgent = "confirmationIsAgent"
   val penaltiesHasSeenConfirmationPage = "penaltiesHasSeenConfirmationPage"
+  val previouslySubmittedJourneyId = "previouslySubmittedJourneyId"
+  val fileNames = "fileNames"
 
   val allKeys: Seq[String] = Seq(
     appealType,
@@ -99,7 +94,6 @@ object SessionKeys {
     isObligationAppeal,
     cancelVATRegistration,
     otherRelevantInformation,
-    journeyId,
     errorCodeFromUpscan,
     failureMessageFromUpscan,
     fileReference,
@@ -114,16 +108,5 @@ object SessionKeys {
     secondPenaltyAmount,
     firstPenaltyCommunicationDate,
     secondPenaltyCommunicationDate
-  )
-
-  val confirmationPageKeys: Seq[String] = Seq(
-    confirmationAppealType,
-    confirmationStartDate,
-    confirmationEndDate,
-    confirmationObligation,
-    confirmationDigitalComms,
-    confirmationMultipleAppeals,
-    confirmationIsAgent,
-    penaltiesHasSeenConfirmationPage
   )
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -128,7 +128,9 @@ POST       /cancel-vat-registration              controllers.CancelVATRegistrati
 GET        /check-your-answers              controllers.CheckYourAnswersController.onPageLoad()
 POST       /check-your-answers              controllers.CheckYourAnswersController.onSubmit()
 GET        /change-answer                   controllers.CheckYourAnswersController.changeAnswer(continueUrl: String, page: String)
-GET        /appeal-confirmation              controllers.CheckYourAnswersController.onPageLoadForConfirmation()
+
+# Appeal Confirmation page
+GET        /appeal-confirmation              controllers.AppealConfirmationController.onPageLoad()
 
 # Making a late appeal page
 GET        /making-a-late-appeal            controllers.MakingALateAppealController.onPageLoad()

--- a/it/controllers/AppealConfirmationControllerISpec.scala
+++ b/it/controllers/AppealConfirmationControllerISpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import org.mongodb.scala.Document
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.UploadJourneyRepository
+import stubs.AuthStub
+import uk.gov.hmrc.http.SessionKeys.authToken
+import utils.{IntegrationSpecCommonBase, SessionKeys}
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext
+
+class AppealConfirmationControllerISpec extends IntegrationSpecCommonBase {
+  val controller: AppealConfirmationController = injector.instanceOf[AppealConfirmationController]
+  val repository: UploadJourneyRepository = injector.instanceOf[UploadJourneyRepository]
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+
+  override def beforeEach(): Unit = {
+    await(repository.collection.deleteMany(Document()).toFuture())
+    super.beforeEach()
+  }
+
+  "GET /appeal-confirmation" should {
+    "show the appeal confirmation page when the user has answers in Mongo" in new UserAnswersSetup(userAnswers(Json.obj(
+      SessionKeys.reasonableExcuse -> "crime",
+      SessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+      SessionKeys.hasConfirmedDeclaration -> true,
+      SessionKeys.dateOfCrime -> LocalDate.parse("2022-01-01"),
+      SessionKeys.isUploadEvidence -> "yes"
+    ))) {
+      val fakeRequest = FakeRequest("GET", "/").withSession(
+        authToken -> "1234",
+        SessionKeys.journeyId -> "1235",
+        SessionKeys.previouslySubmittedJourneyId -> "1234",
+        SessionKeys.penaltiesHasSeenConfirmationPage -> "true"
+      )
+      val result = controller.onPageLoad()(fakeRequest)
+      status(result) shouldBe Status.OK
+    }
+
+    "show the appeal confirmation page when the user has no answers in Mongo" in new UserAnswersSetup(userAnswers(Json.obj(
+      SessionKeys.reasonableExcuse -> "crime",
+      SessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+      SessionKeys.hasConfirmedDeclaration -> true,
+      SessionKeys.dateOfCrime -> LocalDate.parse("2022-01-01"),
+      SessionKeys.isUploadEvidence -> "yes"
+    ))) {
+      val fakeRequest = FakeRequest("GET", "/").withSession(
+        authToken -> "1234",
+        SessionKeys.journeyId -> "1236",
+        SessionKeys.previouslySubmittedJourneyId -> "1235",
+        SessionKeys.penaltiesHasSeenConfirmationPage -> "true"
+      )
+      val result = controller.onPageLoad()(fakeRequest)
+      status(result) shouldBe Status.SEE_OTHER
+      redirectLocation(result).get shouldBe controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData().url
+    }
+
+    "return 303 (SEE_OTHER) when the user is not authorised" in {
+      AuthStub.unauthorised()
+      val result = await(buildClientForRequestToApp(uri = "/appeal-confirmation").get())
+      result.status shouldBe Status.SEE_OTHER
+    }
+  }
+
+}

--- a/it/controllers/CheckYourAnswersControllerISpec.scala
+++ b/it/controllers/CheckYourAnswersControllerISpec.scala
@@ -29,17 +29,16 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.UploadJourneyRepository
 import stubs.{AuthStub, PenaltiesStub}
-import uk.gov.hmrc.http.SessionKeys.authToken
 import utils.{IntegrationSpecCommonBase, SessionKeys}
 
 import java.time.{LocalDate, LocalDateTime}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
   val controller: CheckYourAnswersController = injector.instanceOf[CheckYourAnswersController]
   val repository: UploadJourneyRepository = injector.instanceOf[UploadJourneyRepository]
   val correlationId: String = "correlationId"
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
 
   override def beforeEach(): Unit = {
     await(repository.collection.deleteMany(Document()).toFuture())
@@ -433,7 +432,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest.withSession(SessionKeys.journeyId -> "testjourney")))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       await(userAnswersRepository.getUserAnswer("testjourney")).isDefined shouldBe true
     }
 
@@ -446,7 +445,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the confirmation page on success for fire or flood" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -457,7 +456,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the confirmation page on success for loss of staff" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -468,7 +467,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the confirmation page on success for technical issues" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -480,7 +479,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the confirmation page on success for health" when {
@@ -493,7 +492,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "there is a ongoing hospital stay" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -506,7 +505,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "there has been a hospital stay that has ended" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -520,7 +519,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
     }
@@ -536,7 +535,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "the user has uploaded a file" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -549,7 +548,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "no file upload - late appeal" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -563,7 +562,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "file upload - late appeal" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -577,7 +576,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "for LPP" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -592,7 +591,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         PenaltiesStub.successfulAppealSubmission(isLPP = true, "1234")
         val request = await(controller.onSubmit()(fakeRequest))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "for LPP - agent" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -610,7 +609,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         )
         val request = await(controller.onSubmit()(fakeRequestWithCorrectKeys))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "for LPP2 - agent" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -628,7 +627,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
         )
         val request = await(controller.onSubmit()(fakeRequestWithCorrectKeys))
         request.header.status shouldBe Status.SEE_OTHER
-        request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
     }
 
@@ -640,7 +639,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the confirmation page on success for obligation appeal" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -652,7 +651,7 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       PenaltiesStub.successfulAppealSubmission(isLPP = false, "1234")
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe Status.SEE_OTHER
-      request.header.headers(LOCATION) shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+      request.header.headers(LOCATION) shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
     }
 
     "redirect the user to the service unavailable page on unmatched fault" in new UserAnswersSetup(userAnswers(Json.obj(
@@ -737,31 +736,6 @@ class CheckYourAnswersControllerISpec extends IntegrationSpecCommonBase {
       val request = await(controller.onSubmit()(fakeRequest))
       request.header.status shouldBe SEE_OTHER
       request.header.headers(LOCATION) shouldBe controllers.routes.ProblemWithServiceController.onPageLoad().url
-    }
-
-    "return 303 (SEE_OTHER) when the user is not authorised" in {
-      AuthStub.unauthorised()
-      val request = await(buildClientForRequestToApp(uri = "/check-your-answers").post("{}"))
-      request.status shouldBe Status.SEE_OTHER
-    }
-  }
-
-  "GET /appeal-confirmation" should {
-    "redirect the user to the confirmation page on success" in new UserAnswersSetup(userAnswers(Json.obj(
-      SessionKeys.reasonableExcuse -> "crime",
-      SessionKeys.hasCrimeBeenReportedToPolice -> "yes",
-      SessionKeys.hasConfirmedDeclaration -> true,
-      SessionKeys.dateOfCrime -> LocalDate.parse("2022-01-01"),
-      SessionKeys.isUploadEvidence -> "yes"
-    ))) {
-      val fakeRequest = FakeRequest("GET", "/").withSession(
-        authToken -> "1234",
-        SessionKeys.journeyId -> "1235",
-        SessionKeys.previouslySubmittedJourneyId -> "1234",
-        SessionKeys.penaltiesHasSeenConfirmationPage -> "true"
-      )
-      val request = await(controller.onPageLoadForConfirmation()(fakeRequest))
-      request.header.status shouldBe Status.OK
     }
 
     "return 303 (SEE_OTHER) when the user is not authorised" in {

--- a/it/repositories/UploadJourneyRepositoryISpec.scala
+++ b/it/repositories/UploadJourneyRepositoryISpec.scala
@@ -148,21 +148,6 @@ class UploadJourneyRepositoryISpec extends IntegrationSpecCommonBase {
     }
   }
 
-  "removeUploadsForJourney" should {
-    "remove the document for the given journey ID" in new Setup {
-      await(repository.updateStateOfFileUpload("1234", callbackModel, isInitiateCall = true))
-      await(repository.collection.countDocuments().toFuture()) shouldBe 1
-      await(repository.removeUploadsForJourney("1234"))
-      await(repository.collection.countDocuments().toFuture()) shouldBe 0
-    }
-
-    "not remove anything when the journey ID doesn't exist in the repo" in new Setup {
-      await(repository.collection.countDocuments().toFuture()) shouldBe 0
-      await(repository.removeUploadsForJourney("1234"))
-      await(repository.collection.countDocuments().toFuture()) shouldBe 0
-    }
-  }
-
   "removeFileForJourney" should {
     "remove the file in the journey if it exists" in new Setup {
       await(repository.updateStateOfFileUpload("1234", callbackModel, isInitiateCall = true))

--- a/it/repositories/UserAnswersRepositoryISpec.scala
+++ b/it/repositories/UserAnswersRepositoryISpec.scala
@@ -89,21 +89,4 @@ class UserAnswersRepositoryISpec extends IntegrationSpecCommonBase {
       getResult.isEmpty shouldBe true
     }
   }
-
-  "deleteUserAnswers" should {
-    "return 1 when there is a pre-existing record under the journeyId" in new Setup {
-      await(repository.upsertUserAnswer(userAnswers))
-      val recordsInMongoAfterInsertion = await(repository.collection.find().toFuture())
-      recordsInMongoAfterInsertion.size shouldBe 1
-      val deleteResult = await(repository.deleteUserAnswers("journey123"))
-      deleteResult shouldBe 1
-      val recordsInMongoAfterDeletion = await(repository.collection.find().toFuture())
-      recordsInMongoAfterDeletion.size shouldBe 0
-    }
-
-    "return 0 when there is no pre-existing record under the journeyId" in new Setup {
-      val deleteResult = await(repository.deleteUserAnswers("journey123"))
-      deleteResult shouldBe 0
-    }
-  }
 }

--- a/test/base/UserAnswersBase.scala
+++ b/test/base/UserAnswersBase.scala
@@ -34,15 +34,6 @@ trait UserAnswersBase {
     SessionKeys.journeyId -> "1234"
   )
 
-  val confirmationPageAnswers: JsObject = Json.obj(
-    SessionKeys.confirmationAppealType -> PenaltyTypeEnum.Late_Submission.toString,
-    SessionKeys.confirmationStartDate -> LocalDate.parse("2020-01-01"),
-    SessionKeys.confirmationEndDate -> LocalDate.parse("2020-01-01"),
-    SessionKeys.confirmationMultipleAppeals -> "no",
-    SessionKeys.confirmationObligation -> "false",
-    SessionKeys.confirmationIsAgent -> "false"
-  ) ++ correctUserAnswers
-
   val correctLPPUserAnswers: JsObject = correctUserAnswers ++ Json.obj(
     SessionKeys.appealType -> PenaltyTypeEnum.Late_Payment
   )
@@ -72,16 +63,6 @@ trait UserAnswersBase {
     SessionKeys.hasConfirmedDeclaration -> true,
     SessionKeys.dateOfFireOrFlood -> LocalDate.parse("2022-01-01")
   ) ++ hasConfirmedDeclaration
-
-  val confirmationSessionKeys = Seq(
-    SessionKeys.confirmationAppealType -> PenaltyTypeEnum.Late_Submission.toString,
-    SessionKeys.confirmationStartDate -> LocalDate.parse("2020-01-01").toString,
-    SessionKeys.confirmationEndDate -> LocalDate.parse("2020-01-01").toString,
-    SessionKeys.confirmationMultipleAppeals -> "no",
-    SessionKeys.confirmationObligation -> "false",
-    SessionKeys.confirmationIsAgent -> "false",
-    SessionKeys.penaltiesHasSeenConfirmationPage -> "true"
-  )
 
   val lossOfStaffAnswers: JsObject = Json.obj(
     SessionKeys.reasonableExcuse -> "lossOfStaff",
@@ -153,13 +134,4 @@ trait UserAnswersBase {
     SessionKeys.hasCrimeBeenReportedToPolice -> "yes",
     SessionKeys.dateOfCrime -> "2022-01-01"
   ) ++ hasConfirmedDeclaration
-
-  val confirmationPageKeys: JsObject = Json.obj(
-    SessionKeys.confirmationAppealType -> PenaltyTypeEnum.Late_Submission.toString,
-    SessionKeys.confirmationStartDate -> LocalDate.parse("2020-01-01"),
-    SessionKeys.confirmationEndDate -> LocalDate.parse("2020-01-01"),
-    SessionKeys.confirmationMultipleAppeals -> "no",
-    SessionKeys.confirmationObligation -> "false",
-    SessionKeys.confirmationIsAgent -> "false"
-  ) ++ crimeAnswers
 }

--- a/test/controllers/AppealConfirmationControllerSpec.scala
+++ b/test/controllers/AppealConfirmationControllerSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import helpers.SessionAnswersHelper
+import models.UserRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import play.api.http.Status._
+import play.api.libs.json.JsObject
+import play.api.mvc.{AnyContent, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout, redirectLocation, status}
+import testUtils.AuthTestModels
+import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import utils.SessionKeys
+import views.html.AppealConfirmationPage
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AppealConfirmationControllerSpec extends SpecBase {
+  val page: AppealConfirmationPage = injector.instanceOf[AppealConfirmationPage]
+  val sessionAnswersHelper: SessionAnswersHelper = injector.instanceOf[SessionAnswersHelper]
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+
+  def fakeRequest(answers: JsObject, fakeRequest: FakeRequest[AnyContent] = fakeRequest): UserRequest[AnyContent] = fakeRequestConverter(answers, fakeRequest)
+
+  class Setup(authResult: Future[~[Option[AffinityGroup], Enrolments]]) {
+    reset(mockAuthConnector)
+    reset(mockSessionService)
+    reset(mockAppConfig)
+    when(mockAuthConnector.authorise[~[Option[AffinityGroup], Enrolments]](
+      any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(
+      any(), any())
+    ).thenReturn(authResult)
+  }
+
+  object Controller extends AppealConfirmationController(
+    mockSessionService,
+    page
+  )(implicitly, implicitly, implicitly, stubMessagesControllerComponents(), authPredicate)
+
+  "onPageLoad" should {
+    "the user is authorised" when {
+      "show the confirmation page and remove all non-confirmation screen session keys (loading data from Mongo)" in new Setup(AuthTestModels.successfulAuthResult) {
+        val fakeRequestWithPreviouslySubmittedJourneyIdKey: FakeRequest[AnyContent] = FakeRequest("GET", "/").withSession(SessionKeys.previouslySubmittedJourneyId -> "1235")
+        when(mockSessionService.getUserAnswers(any()))
+          .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
+        val result: Future[Result] = Controller.onPageLoad()(fakeRequest(crimeAnswers, fakeRequestWithPreviouslySubmittedJourneyIdKey))
+        await(result).header.status shouldBe OK
+        await(result).session.data.keys.toSet.subsetOf(SessionKeys.allKeys.toSet) shouldBe false
+      }
+
+      "redirect the user to the no journey data error page when the user is missing the 'previouslySubmittedJourneyId' key" in new Setup(AuthTestModels.successfulAuthResult) {
+        when(mockSessionService.getUserAnswers(any()))
+          .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
+        val result: Future[Result] = Controller.onPageLoad()(fakeRequest(crimeAnswers, fakeRequest))
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result).get shouldBe controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData().url
+      }
+    }
+
+    "the user is unauthorised" when {
+
+      "return 403 (FORBIDDEN) when user has no enrolments" in new Setup(AuthTestModels.failedAuthResultNoEnrolments) {
+        val result: Future[Result] = Controller.onPageLoad()(fakeRequest)
+        status(result) shouldBe FORBIDDEN
+      }
+
+      "return 303 (SEE_OTHER) when user can not be authorised" in new Setup(AuthTestModels.failedAuthResultUnauthorised) {
+        val result: Future[Result] = Controller.onPageLoad()(fakeRequest)
+        status(result) shouldBe SEE_OTHER
+      }
+    }
+  }
+}

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -27,21 +27,20 @@ import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContent, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{await, defaultAwaitTimeout, redirectLocation, session, status}
+import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, session, status}
 import services.AppealService
 import testUtils.AuthTestModels
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import utils.SessionKeys
-import views.html.{AppealConfirmationPage, CheckYourAnswersPage}
+import views.html.CheckYourAnswersPage
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class CheckYourAnswersControllerSpec extends SpecBase {
   implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
   val page: CheckYourAnswersPage = injector.instanceOf[CheckYourAnswersPage]
-  val confirmationPage: AppealConfirmationPage = injector.instanceOf[AppealConfirmationPage]
   val mockAppealService: AppealService = mock(classOf[AppealService])
   val sessionAnswersHelper: SessionAnswersHelper = injector.instanceOf[SessionAnswersHelper]
   val mockIsLateAppeal:IsLateAppealHelper = mock(classOf[IsLateAppealHelper])
@@ -65,9 +64,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
   object Controller extends CheckYourAnswersController(
     page,
     mockAppealService,
-    confirmationPage,
     errorHandler,
-    mockSessionService,
     sessionAnswersHelper,
     mockIsLateAppeal
   )(stubMessagesControllerComponents(), implicitly, implicitly, implicitly, authPredicate, dataRetrievalAction, dataRequiredAction, checkObligationAvailabilityAction)
@@ -221,7 +218,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
           .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
         val result: Future[Result] = Controller.onSubmit()(fakeRequest(crimeAnswers))
         status(result) shouldBe SEE_OTHER
-        redirectLocation(result).get shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        redirectLocation(result).get shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
         session(result).get(SessionKeys.previouslySubmittedJourneyId).get shouldBe "1234"
       }
 
@@ -232,7 +229,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
           .thenReturn(Future.successful(Some(userAnswers(obligationAnswers))))
         val result: Future[Result] = Controller.onSubmit()(fakeRequest(obligationAnswers))
         status(result) shouldBe SEE_OTHER
-        redirectLocation(result).get shouldBe controllers.routes.CheckYourAnswersController.onPageLoadForConfirmation().url
+        redirectLocation(result).get shouldBe controllers.routes.AppealConfirmationController.onPageLoad().url
       }
 
       "redirect the user to an ISE" when {
@@ -355,35 +352,24 @@ class CheckYourAnswersControllerSpec extends SpecBase {
     }
   }
 
-  "onPageLoadForConfirmation" should {
-    "the user is authorised" when {
-      "show the confirmation page and remove all non-confirmation screen session keys (loading data from Mongo)" in new Setup(AuthTestModels.successfulAuthResult) {
-        val fakeRequestWithPreviouslySubmittedJourneyIdKey: FakeRequest[AnyContent] = FakeRequest("GET", "/").withSession(SessionKeys.previouslySubmittedJourneyId -> "1235")
-        when(mockSessionService.getUserAnswers(any()))
-          .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
-        val result: Future[Result] = Controller.onPageLoadForConfirmation()(fakeRequest(crimeAnswers, fakeRequestWithPreviouslySubmittedJourneyIdKey))
-        await(result).header.status shouldBe OK
-        await(result).session.data.keys.toSet.subsetOf(SessionKeys.allKeys.toSet) shouldBe false
-      }
-
-      "redirect the user to the no journey data error page when the user is missing the 'previouslySubmittedJourneyId' key" in new Setup(AuthTestModels.successfulAuthResult) {
-        when(mockSessionService.getUserAnswers(any()))
-          .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
-        val result: Future[Result] = Controller.onPageLoadForConfirmation()(fakeRequest(crimeAnswers, fakeRequest))
-        status(result) shouldBe SEE_OTHER
-        redirectLocation(result).get shouldBe controllers.routes.IncompleteSessionDataController.onPageLoadWithNoJourneyData().url
-      }
+  "changeAnswer" should {
+    "redirect to the URL provided and add the page name to the session" in new Setup(AuthTestModels.successfulAuthResult) {
+      when(mockSessionService.getUserAnswers(any()))
+        .thenReturn(Future.successful(Some(userAnswers(crimeAnswers))))
+      val result: Future[Result] = Controller.changeAnswer(controllers.routes.ReasonableExcuseController.onPageLoad().url, "ReasonableExcuseSelectionPage")(fakeRequest)
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result).get shouldBe controllers.routes.ReasonableExcuseController.onPageLoad().url
     }
 
-    "the user is unauthorised" when {
+    "when the user is unauthorised" when {
 
       "return 403 (FORBIDDEN) when user has no enrolments" in new Setup(AuthTestModels.failedAuthResultNoEnrolments) {
-        val result: Future[Result] = Controller.onSubmit()(fakeRequest)
+        val result: Future[Result] = Controller.changeAnswer(controllers.routes.ReasonableExcuseController.onPageLoad().url, "ReasonableExcuseSelectionPage")(fakeRequest)
         status(result) shouldBe FORBIDDEN
       }
 
       "return 303 (SEE_OTHER) when user can not be authorised" in new Setup(AuthTestModels.failedAuthResultUnauthorised) {
-        val result: Future[Result] = Controller.onSubmit()(fakeRequest)
+        val result: Future[Result] = Controller.changeAnswer(controllers.routes.ReasonableExcuseController.onPageLoad().url, "ReasonableExcuseSelectionPage")(fakeRequest)
         status(result) shouldBe SEE_OTHER
       }
     }

--- a/test/controllers/predicates/DataRequiredActionSpec.scala
+++ b/test/controllers/predicates/DataRequiredActionSpec.scala
@@ -18,7 +18,6 @@ package controllers.predicates
 
 import base.SpecBase
 import models.UserRequest
-import models.session.UserAnswers
 import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.mvc.Results.Ok
@@ -73,8 +72,8 @@ class DataRequiredActionSpec extends SpecBase {
 
     "redirect to the appeal has already been submitted page" when {
       "the user has seen the appeal confirmation page" in {
-        val requestWithConfirmationSessionKeys = UserRequest("123456789", answers = UserAnswers("")
-        )(FakeRequest("GET", "/").withSession(SessionKeys.penaltiesHasSeenConfirmationPage -> "true"))
+        val requestWithConfirmationSessionKeys = UserRequest("123456789", answers = userAnswers(correctUserAnswers)
+        )(FakeRequest("GET", "/").withSession(SessionKeys.penaltiesHasSeenConfirmationPage -> "true", SessionKeys.journeyId -> "1234"))
         val fakeController = new Harness(
           requiredAction = new DataRequiredActionImpl(
             errorHandler

--- a/test/controllers/predicates/DataRetrievalActionSpec.scala
+++ b/test/controllers/predicates/DataRetrievalActionSpec.scala
@@ -18,14 +18,12 @@ package controllers.predicates
 
 import base.SpecBase
 import models.AuthRequest
-import models.session.UserAnswers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import play.api.mvc.Results.Ok
 import play.api.mvc.{Request, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import utils.SessionKeys
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -41,9 +39,9 @@ class DataRetrievalActionSpec extends SpecBase {
 
   "refine" should {
     "return OK" when {
-      "there is a 'penaltiesHasSeenConfirmationPage' session key" in {
-        when(mockSessionService.getUserAnswers(any())).thenReturn(Future.successful(Some(UserAnswers("1234"))))
-        val requestWithNoSessionKeys = AuthRequest("123456789")(fakeRequest.withSession(SessionKeys.penaltiesHasSeenConfirmationPage -> "true"))
+      "there is session data" in {
+        when(mockSessionService.getUserAnswers(any())).thenReturn(Future.successful(None))
+        val requestWithNoSessionKeys = AuthRequest("123456789")(fakeRequest)
         val fakeController = new Harness(
           retrievalAction = new DataRetrievalActionImpl(
             mockSessionService,


### PR DESCRIPTION
Answers and files with expire via TTL
Journey ID of successful is also stored under a new key called 'previouslySubmittedJourneyId' for later use
Removed dependency on confirmation page keys in session and moved to Mongo - which should decrease size of cookie